### PR TITLE
get dscs from v2

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/config/WsBaseConfig.java
@@ -34,7 +34,7 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     @Value("${verifier.baseurl}")
     private String verifierBaseUrl;
 
-    @Value("${verifier.dsc.endpoint:/trust/v1/keys/updates}")
+    @Value("${verifier.dsc.endpoint:/trust/v2/keys/updates}")
     private String dscEndpoint;
 
     @Value("${verifier.revocation.endpoint:/trust/v1/revocationList}")

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerificationService.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerificationService.java
@@ -38,6 +38,8 @@ public class VerificationService {
     private static final String UP_TO_DATE_HEADER = "up-to-date";
     private static final String NEXT_SINCE_HEADER = "X-Next-Since";
     private static final String SINCE_PARAM = "since";
+    private static final String CERT_FORMAT_PARAM = "certFormat";
+    private static final String UP_TO_PARAM = "upTo";
 
     private final String verifierBaseUrl;
     private final String dscEndpoint;
@@ -101,8 +103,8 @@ public class VerificationService {
 
     private Map<String, String> getKeyUpdatesParams() {
         final var params = new HashMap<String, String>();
-        String CERT_FORMAT_PARAM = "certFormat";
         params.put(CERT_FORMAT_PARAM, CertFormat.ANDROID.name());
+        params.put(UP_TO_PARAM, String.valueOf(Long.MAX_VALUE));
         return params;
     }
 


### PR DESCRIPTION
this pull request changes the key fetch endpoint from v1 to v2. by configuring the `verifier.dsc.endpoint` property v1 can still be used if needed.