### PR TITLE
check if trust list is valid/up-to-date

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/TrustListConfig.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/TrustListConfig.java
@@ -1,10 +1,12 @@
 package ch.admin.bag.covidcertificate.backend.verification.check.ws.model;
 
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.TrustList;
+import java.time.Instant;
 
 public class TrustListConfig {
 
     private TrustList trustList;
+    private Instant lastSync;
 
     public TrustList getTrustList() {
         return trustList;
@@ -12,5 +14,21 @@ public class TrustListConfig {
 
     public void setTrustList(TrustList trustList) {
         this.trustList = trustList;
+    }
+
+    public Instant getLastSync() {
+        return lastSync;
+    }
+
+    public void setLastSync(Instant lastSync) {
+        this.lastSync = lastSync;
+    }
+
+    public boolean isOutdated() {
+        Instant now = Instant.now();
+        return this.lastSync.isBefore(
+                        now.minusMillis(trustList.getRevokedCertificates().getValidDuration()))
+                || this.lastSync.isBefore(
+                        now.minusMillis(trustList.getRuleSet().getValidDuration()));
     }
 }

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/LibWrapperTest.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/LibWrapperTest.java
@@ -12,7 +12,6 @@ import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckNationalRulesSta
 import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckRevocationState;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckSignatureState;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.DecodeState;
-import ch.admin.bag.covidcertificate.sdk.core.models.state.DecodeState.ERROR;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.DecodeState.SUCCESS;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState.INVALID;


### PR DESCRIPTION
this pull request adds a check that the data in the trust list config is up-to-date. when the config is out-of-date an invalid state is returned. signature validation however is possible in any case.