### PR TITLE
backported SDK hotfix for sero-positive

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>ch.admin.bag.covidcertificate</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>1.1.3</version>
+            <version>1.1.3-sero</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
changed the SDK version to 1.1.3-sero to fix validity calculation for antibody tests until the SDK is updated properly