### PR TITLE
Configure spring profile in docker container with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Download and start the container by running
 docker run -p 8080:8080 -e APIKEY=<API obtained from BAG> adminch/covidcertificate-app-verification-check-service:latest
 ```
 
-The service is now exposed on port 8080 (change the first number in the `-p` argument to change the port).
+The service is now exposed on port 8080 (change the first number in the `-p` argument to change the port). By default, the service will connect to the `prod` environment, which should be used to verify actual certificates. For testing and development, add `-e ENV=dev` or `-e ENV=abn` to change to the respective environment.
 
 ### Verifying certificates
 

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/jib/config/application.properties
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/jib/config/application.properties
@@ -9,7 +9,7 @@
 #
 
 # Change profile "detailed" to "simple" to use the SimpleController (i.e. simplified verify response)
-spring.profiles.active=prod,simple
+spring.profiles.active=${ENV:prod},simple
 management.endpoints.enabled-by-default=false
 server.error.whitelabel.enabled=true
 


### PR DESCRIPTION
if the `ENV` environment variable is specified when running the docker container, the `prod` profile can be changed to `dev` or `abn`