### PR TITLE
add config class for abn

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/config/AbnConfig.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/config/AbnConfig.java
@@ -1,0 +1,9 @@
+package ch.admin.bag.covidcertificate.backend.verification.check.ws.config;
+
+import ch.admin.bag.covidcertificate.backend.verification.check.ws.config.WsBaseConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("abn")
+public class AbnConfig extends WsBaseConfig {}


### PR DESCRIPTION
Adds a config class for the `abn` environment in line with those for `prod` and `dev`. Without it, Spring won't start in the `abn` env.