### PR TITLE
Update SDK to 3.0.0 with verification mode support

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-model/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/model/SimpleControllerPayload.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-model/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/model/SimpleControllerPayload.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.verification.check.model;
+
+import ch.ubique.openapi.docannotations.Documentation;
+import javax.validation.constraints.NotNull;
+
+public class SimpleControllerPayload extends HCertPayload {
+    @NotNull
+    private String mode;
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+}

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>ch.admin.bag.covidcertificate</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.0.4</version>
+            <version>3.0</version>
         </dependency>
 
         <dependency>

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/SimpleController.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/SimpleController.java
@@ -1,6 +1,7 @@
 package ch.admin.bag.covidcertificate.backend.verification.check.ws.controller;
 
 import ch.admin.bag.covidcertificate.backend.verification.check.model.HCertPayload;
+import ch.admin.bag.covidcertificate.backend.verification.check.model.SimpleControllerPayload;
 import ch.admin.bag.covidcertificate.backend.verification.check.ws.model.DecodingException;
 import ch.admin.bag.covidcertificate.backend.verification.check.ws.model.SimpleVerificationResponse;
 import ch.admin.bag.covidcertificate.backend.verification.check.ws.verification.VerificationService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -44,15 +46,18 @@ public class SimpleController {
             })
     @CrossOrigin(origins = {"https://editor.swagger.io"})
     @PostMapping("/verify")
-    public @ResponseBody SimpleVerificationResponse verify(@RequestBody HCertPayload hCertPayload) {
+    public @ResponseBody SimpleVerificationResponse verify(@RequestBody SimpleControllerPayload hCertPayload) {
+        String verificationMode = hCertPayload.getMode();
         final var start = Instant.now();
+
         // Decode hcert
         logger.info("Decoding hcert");
         final var certificateHolder = verificationService.decodeHCert(hCertPayload);
 
         logger.info("Verifying hcert");
         // Verify hcert
-        final var verificationState = verificationService.verifyDcc(certificateHolder);
+        final var verificationState = verificationService.verifyDccSingleMode(certificateHolder,
+                verificationMode);
 
         // Build response
         final var simpleVerificationResponse =

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/VerificationController.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/VerificationController.java
@@ -69,7 +69,7 @@ public class VerificationController {
         final var certificateHolder = verificationService.decodeHCert(hCertPayload);
 
         // Verify hcert
-        final var verificationState = verificationService.verifyDcc(certificateHolder);
+        final var verificationState = verificationService.verifyDccAllModes(certificateHolder);
 
         // Build response
         final var verificationResponse = new VerificationResponse();

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/IntermediateRuleSet.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/IntermediateRuleSet.java
@@ -1,6 +1,7 @@
 package ch.admin.bag.covidcertificate.backend.verification.check.ws.model;
 
 //import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.RuleValueSets;
+import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ActiveModes;
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.Description;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,6 +16,7 @@ public class IntermediateRuleSet {
     @NotNull private Map<String, String[]> valueSets;
     @NotNull private Long validDuration;
     @NotNull private List<DisplayRule> displayRules;
+    @NotNull private ModeRules modeRules;
 
     public List<Rule> getRules() {
         return rules;
@@ -49,6 +51,15 @@ public class IntermediateRuleSet {
         this.valueSets = valueSets;
     }
 
+    public ModeRules getModeRules() {
+        return modeRules;
+    }
+
+    public void setModeRules(
+            ModeRules modeRules) {
+        this.modeRules = modeRules;
+    }
+
     public static class Rule {
 
         private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -66,6 +77,7 @@ public class IntermediateRuleSet {
         public List<String> getAffectedFields() {
             return affectedFields;
         }
+
 
         public void setAffectedFields(List<String> affectedFields) {
             this.affectedFields = affectedFields;
@@ -197,6 +209,34 @@ public class IntermediateRuleSet {
             public void setLang(String lang) {
                 this.lang = lang;
             }
+        }
+    }
+
+    public static class ModeRules {
+        private static final ObjectMapper objectMapper = new ObjectMapper();
+        @NotNull private List<ActiveModes> activeModes;
+        @NotNull @JsonRawValue private Object logic;
+
+        public List<ActiveModes> getActiveModes() {
+            return activeModes;
+        }
+
+        public void setActiveModes(
+                List<ActiveModes> activeModes) {
+            this.activeModes = activeModes;
+        }
+
+        @JsonRawValue
+        public String getLogic() {
+            try {
+                return logic == null ? null : objectMapper.writeValueAsString(logic);
+            } catch (JsonProcessingException e) {
+                return null;
+            }
+        }
+
+        public void setLogic(Object logic) {
+            this.logic = logic;
         }
     }
 

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/RevokedCertificatesRepository.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/RevokedCertificatesRepository.java
@@ -1,0 +1,55 @@
+package ch.admin.bag.covidcertificate.backend.verification.check.ws.model;
+
+import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.RevokedCertificatesStore;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public class RevokedCertificatesRepository implements RevokedCertificatesStore {
+    private RevokedCertificates revokedCertificates = new RevokedCertificates(new ArrayList<>(), 0);
+
+    public RevokedCertificatesRepository(RevokedCertificates revokedCertificates){
+        this.revokedCertificates = revokedCertificates;
+    }
+
+    @Override
+    public void addCertificates(@NotNull List<String> list) {
+        revokedCertificates.getRevokedCerts().addAll(list);
+    }
+
+    @Override
+    public boolean containsCertificate(@NotNull String s) {
+        return revokedCertificates.getRevokedCerts().contains(s);
+    }
+
+    public long getValidDuration(){
+        return revokedCertificates.getValidDuration();
+    }
+
+    public static class RevokedCertificates {
+        private List<String> revokedCerts;
+        private long validDuration;
+        public RevokedCertificates(){}
+
+        public RevokedCertificates(List<String> revokedCerts, long validDuration){
+            this.revokedCerts = revokedCerts;
+            this.validDuration = validDuration;
+        }
+
+        public List<String> getRevokedCerts() {
+            return revokedCerts;
+        }
+
+        public void setRevokedCerts(List<String> revokedCerts) {
+            this.revokedCerts = revokedCerts;
+        }
+
+        public long getValidDuration() {
+            return validDuration;
+        }
+
+        public void setValidDuration(long validDuration) {
+            this.validDuration = validDuration;
+        }
+    }
+}

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/TrustListConfig.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/TrustListConfig.java
@@ -8,6 +8,17 @@ public class TrustListConfig {
     private TrustList trustList;
     private Instant lastSync;
 
+    private RevokedCertificatesRepository revokedCertificatesRepository;
+
+    public RevokedCertificatesRepository getRevokedCertificatesRepository() {
+        return revokedCertificatesRepository;
+    }
+
+    public void setRevokedCertificatesRepository(
+            RevokedCertificatesRepository revokedCertificatesRepository) {
+        this.revokedCertificatesRepository = revokedCertificatesRepository;
+    }
+
     public TrustList getTrustList() {
         return trustList;
     }
@@ -27,7 +38,7 @@ public class TrustListConfig {
     public boolean isOutdated() {
         Instant now = Instant.now();
         return this.lastSync.isBefore(
-                        now.minusMillis(trustList.getRevokedCertificates().getValidDuration()))
+                        now.minusMillis(revokedCertificatesRepository.getValidDuration()))
                 || this.lastSync.isBefore(
                         now.minusMillis(trustList.getRuleSet().getValidDuration()));
     }

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/TestData.kt
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/TestData.kt
@@ -22,10 +22,21 @@ object TestData {
     ): TrustList {
         return TrustList(
             Jwks(signingKeys),
-            RevokedCertificates(revokedKeyIds, Long.MAX_VALUE),
+            object: RevokedCertificatesStore{
+                val certs = ArrayList<String>(revokedKeyIds);
+                override fun addCertificates(certificates: List<String>) {
+                    certs.addAll(certificates)
+                }
+
+                override fun containsCertificate(certificate: String): Boolean {
+                    return certs.contains(certificate)
+                }
+            },
+
             ruleSet ?: RuleSet(
                 emptyList(),
                 emptyList(),
+                ModeRules(emptyList(), ""),
                 emptyMap(),
                 0L
                 )

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerifyWrapper.kt
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerifyWrapper.kt
@@ -4,16 +4,28 @@ import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.CertificateHolde
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.TrustList
 import ch.admin.bag.covidcertificate.sdk.core.verifier.CertificateVerifier
+import ch.admin.bag.covidcertificate.sdk.core.verifier.VerificationType
 import kotlinx.coroutines.runBlocking
 
 object VerifyWrapper {
 
     @JvmStatic
-    fun verify(
+    fun verifyWallet(
             certificateVerifier: CertificateVerifier,
             certificateHolder: CertificateHolder,
             trustList: TrustList
     ): VerificationState = runBlocking {
-        certificateVerifier.verify(certificateHolder, trustList);
+        certificateVerifier.verify(certificateHolder, trustList, trustList.ruleSet.modeRules.activeModes.map { it -> it.id }.toSet(), VerificationType.WALLET)
     }
+
+    @JvmStatic
+    fun verifyVerifier(
+        certificateVerifier: CertificateVerifier,
+        certificateHolder: CertificateHolder,
+        trustList: TrustList,
+        mode: String
+    ): VerificationState = runBlocking {
+        certificateVerifier.verify(certificateHolder, trustList, setOf(mode), VerificationType.VERIFIER)
+    }
+
 }

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/LibWrapperTest.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/LibWrapperTest.java
@@ -90,7 +90,7 @@ class LibWrapperTest {
                 TestData.createTrustList(
                         TestData.getHardcodedSigningKeys("abn"), Collections.emptyList(), null);
         VerificationState verificationState =
-                VerifyWrapper.verify(certificateVerifier, certificateHolder, trustList);
+                VerifyWrapper.verifyWallet(certificateVerifier, certificateHolder, trustList);
         assertTrue(verificationState instanceof INVALID);
         assertTrue(
                 ((INVALID) verificationState).getSignatureState()
@@ -106,7 +106,7 @@ class LibWrapperTest {
         trustList =
                 TestData.createTrustList(
                         TestData.getHardcodedSigningKeys("dev"), Collections.emptyList(), null);
-        verificationState = VerifyWrapper.verify(certificateVerifier, certificateHolder, trustList);
+        verificationState = VerifyWrapper.verifyWallet(certificateVerifier, certificateHolder, trustList);
         assertTrue(verificationState instanceof INVALID);
         assertTrue(
                 ((INVALID) verificationState).getSignatureState()

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/VerificationServiceTest.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/VerificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 //import ch.admin.bag.covidcertificate.backend.verification.check.ws.model.IntermediateRuleSet;
 import ch.admin.bag.covidcertificate.backend.verification.check.ws.model.IntermediateRuleSet;
+import ch.admin.bag.covidcertificate.backend.verification.check.ws.model.IntermediateRuleSet.ModeRules;
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.DisplayRule;
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.Jwks;
 import ch.admin.bag.covidcertificate.sdk.core.models.trustlist.Rule;
@@ -100,10 +101,13 @@ class VerificationServiceTest {
                             .collect(Collectors.toList());
 
             logger.info("downloaded {} rules", rules.size());
-
-            final var ruleSet = new RuleSet(
+            ModeRules intermediateModeRules = intermediateRuleSet.getModeRules();
+            ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules sdkModeRules = new ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules(intermediateModeRules.getActiveModes(), intermediateModeRules.getLogic());
+            logger.info("downloaded {} rules", rules.size());
+            RuleSet ruleSet = new RuleSet(
                     displayRules,
                     rules,
+                    sdkModeRules,
                     intermediateRuleSet.getValueSets(),
                     intermediateRuleSet.getValidDuration());
             assertNotNull(ruleSet);


### PR DESCRIPTION
Updates the Kotlin Core SDK to v3.0. This introduces some breaking API changes as the verification logic has changed to indicate the validity of certificates under different modes (3G, 2G etc.)