### PR TITLE
feature/sdk 304

### DIFF
--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>ch.admin.bag.covidcertificate</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.4-dev-41</version>
         </dependency>
 
         <dependency>

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/SimpleController.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/controller/SimpleController.java
@@ -50,6 +50,9 @@ public class SimpleController {
     @PostMapping("/verify")
     public @ResponseBody SimpleVerificationResponse verify(@RequestBody SimpleControllerPayload hCertPayload) {
         String verificationMode = hCertPayload.getMode();
+        if(!getVerificationModes().contains(verificationMode)){
+            throw new IllegalArgumentException("Invalid or no verification mode provided. Query /modes for currently available modes");
+        }
         final var start = Instant.now();
 
         // Decode hcert
@@ -89,10 +92,20 @@ public class SimpleController {
     }
 
 
-        @ExceptionHandler(DecodingException.class)
+    @ExceptionHandler(DecodingException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<String> invalidHCert(DecodingException e) {
         logger.info("Decoding exception thrown: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMsg());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> invalidMode(IllegalArgumentException e) {
+        logger.info("IllegalArgumentException thrown: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+
 }
+

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/IntermediateRuleSet.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/model/IntermediateRuleSet.java
@@ -214,6 +214,7 @@ public class IntermediateRuleSet {
         private static final ObjectMapper objectMapper = new ObjectMapper();
         @NotNull private List<ActiveModes> activeModes;
         @NotNull private List<ActiveModes> verifierActiveModes;
+        @NotNull private List<ActiveModes> walletActiveModes;
         @NotNull @JsonRawValue private Object logic;
 
 
@@ -246,6 +247,15 @@ public class IntermediateRuleSet {
 
         public void setLogic(Object logic) {
             this.logic = logic;
+        }
+
+        public List<ActiveModes> getWalletActiveModes() {
+            return walletActiveModes;
+        }
+
+        public void setWalletActiveModes(
+                List<ActiveModes> walletActiveModes) {
+            this.walletActiveModes = walletActiveModes;
         }
     }
 

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/TestData.kt
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/TestData.kt
@@ -36,7 +36,7 @@ object TestData {
             ruleSet ?: RuleSet(
                 emptyList(),
                 emptyList(),
-                ModeRules(emptyList(), emptyList(), ""),
+                ModeRules(emptyList(), emptyList(), emptyList(), ""),
                 emptyMap(),
                 0L
             )

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerificationService.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/verification/VerificationService.java
@@ -248,7 +248,7 @@ public class VerificationService {
                         .map(rule -> new DisplayRule(rule.getId(), rule.getLogic()))
                         .collect(Collectors.toList());
         ModeRules intermediateModeRules = intermediateRuleSet.getModeRules();
-        ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules sdkModeRules = new ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules(intermediateModeRules.getActiveModes(), intermediateModeRules.getVerifierActiveModes(), intermediateModeRules.getLogic());
+        ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules sdkModeRules = new ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules(intermediateModeRules.getActiveModes(), intermediateModeRules.getWalletActiveModes(), intermediateModeRules.getVerifierActiveModes(), intermediateModeRules.getLogic());
         logger.info("downloaded {} rules", rules.size());
 
         return new RuleSet(

--- a/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/VerificationServiceTest.java
+++ b/ch-covidcertificate-backend-verification-check/ch-covidcertificate-backend-verification-check-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verification/check/ws/util/VerificationServiceTest.java
@@ -101,7 +101,7 @@ class VerificationServiceTest {
 
             logger.info("downloaded {} rules", rules.size());
             ModeRules intermediateModeRules = intermediateRuleSet.getModeRules();
-            ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules sdkModeRules = new ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules(intermediateModeRules.getActiveModes(), intermediateModeRules.getVerifierActiveModes(), intermediateModeRules.getLogic());
+            ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules sdkModeRules = new ch.admin.bag.covidcertificate.sdk.core.models.trustlist.ModeRules(intermediateModeRules.getActiveModes(), intermediateModeRules.getWalletActiveModes(), intermediateModeRules.getVerifierActiveModes(), intermediateModeRules.getLogic());
             logger.info("downloaded {} rules", rules.size());
             RuleSet ruleSet = new RuleSet(
                     displayRules,


### PR DESCRIPTION
- update SDK to 3.0.4 (walletVerificationModes)
- simple controller: return bad request if no or invalid verification mode is provided

SDK 3.0.4 should fix the issue where the transformation-service could not issue a light cert on the last day of validity
