### PR TITLE
renovate: Update core SDK separately and skip dev releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,13 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "groupName": "dependencies"
+      "groupName": "dependencies",
+      "excludePackageNames": ["ch.admin.bag.covidcertificate:sdk-core"]
+    },
+    {
+      "matchPackageNames": ["ch.admin.bag.covidcertificate:sdk-core"],
+      "allowedVersions": "!/.*-dev-.*/",
+      "groupName": "core-sdk"
     }
   ],
   "schedule": [


### PR DESCRIPTION
This PR tells Renovate to update the CovidCert Core SDK separately from other dependencies since it's the most likely dependency to break things.
It also ignores dev releases